### PR TITLE
Make the expected url on Renderer clearer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Once you have the client installed and an instance of the Hypernova service runn
 ```python
 import hypernova
 
-renderer = hypernova.Renderer('http://localhost')
+renderer = hypernova.Renderer('http://localhost:3030/batch')
 html = renderer.render({'MyComponent.js': {'name': 'Foo'}})
 ```
 


### PR DESCRIPTION
I went into the trap that I took for granted that the library appends "/batch", this should make the expected input more obvious.