### PR TITLE
Fix issue with dev-plugin not working in python 3.5+

### DIFF
--- a/hypernova/plugins/dev_mode.py
+++ b/hypernova/plugins/dev_mode.py
@@ -32,7 +32,7 @@ class DevModePlugin(object):
 
     def after_response(self, current_response, original_response):
         updated = current_response.copy()
-        for name, data in updated.iteritems():
+        for name, data in updated.items():
             if data.get("error"):
                 data["html"] = render_error(name, data)
         return updated

--- a/test/test_hypernova.py
+++ b/test/test_hypernova.py
@@ -1,8 +1,10 @@
+import logging
 import json
 import hypernova
 import unittest
 import unittest.mock as mock
 
+from hypernova.plugins.dev_mode import DevModePlugin
 import utils.mocks as mocks
 import utils.plugins as plugins
 
@@ -123,3 +125,12 @@ class TestPlugins(unittest.TestCase):
         renderer = hypernova.Renderer("http://localhost", [plugins.PluginOnError()])
         renderer.render({"component": {}})
         self.assertEqual(1, mock_plugin.call_count)
+
+
+class TestDevModePlugin(unittest.TestCase):
+    def test_after_response_should_iterate_dict_on_error(self):
+        logger = logging.getLogger(__name__)
+        current = {'App': {'name': 'App'}}
+
+        resp = DevModePlugin(logger).after_response(current, {})
+        self.assertTrue('App' in resp)


### PR DESCRIPTION
I noticed that you missed replacing `iteritems` with `items` in the dev-plugin (I did the same when I migrated the library in my older fork). This PR adds a regression test along with a fix.